### PR TITLE
Adjusted instructions to import libraries Lab-1 and 3

### DIFF
--- a/01-consume-bedrock-models-via-genaihub.ipynb
+++ b/01-consume-bedrock-models-via-genaihub.ipynb
@@ -596,12 +596,20 @@
     "## Part 2 Use SAP GenAI Hub SDK\n",
     "Reference code [here](https://help.sap.com/doc/generative-ai-hub-sdk/CLOUD/en-US/_reference/gen_ai_hub.html).\n",
     "\n",
-    "Run below if not installed\n",
-    "```sh\n",
-    "!pip install generative-ai-hub-sdk[amazon] boto3\n",
-    "```"
+    "Run below if not installed\n"
    ]
   },
+  
+    {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install "generative-ai-hub-sdk[all]==4.4.3" "boto3==1.35.27" "langchain==0.3.20" "langgraph==0.3.20""
+   ]
+  },
+  
   {
    "cell_type": "code",
    "execution_count": null,

--- a/03-agentic-workflows-with-langchain-langgraph-via-genaihub.ipynb
+++ b/03-agentic-workflows-with-langchain-langgraph-via-genaihub.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install langchain langgraph \"langchain_aws>=0.2.9\""
+    "!pip install "generative-ai-hub-sdk[all]==4.4.3" "boto3==1.35.27" "langchain==0.3.20" "langgraph==0.3.20""
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
SAP Generative AI Hub SDK's multi-provider architecture requires installing all dependencies (generative-ai-hub-sdk[all] and google-cloud-aiplatform) even when only using Amazon features, as it loads provider modules during initialization regardless of usage.

*Description of changes:*
Added a more streamlined way to import libraries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
